### PR TITLE
Tooltip informing when capslock is on

### DIFF
--- a/AutoHotkey.ahk
+++ b/AutoHotkey.ahk
@@ -72,3 +72,21 @@ If (WinActive("ahk_class %win_class%")) {
 				send g
 		return
 }	 
+
+
+; Tooltip in top left corner informin when capslock is activated
+CapsLock::SetCapslockState, % ( Toggle( capsLockState ) ? "On" : "Off" )
+
+Toggle(byRef onOff)
+{
+;	onOff := ( onOff == 0 ) ? 1 : 0
+if (onOff == 0) {
+	ToolTip, command mode, A_ScreenWidth, 0
+	onOff = 1
+	}
+else {
+	ToolTip
+	onOff = 0
+	}
+return onOff
+}


### PR DESCRIPTION
It is my first commit ever on github...

I was trying to do the same thing on AHK and when searching on github for something similar I found your script. It does exactly what I was trying to do, easy and simple. I just added the tooltip because sometimes I accidentally hit the CapsLock button, and in my keyboard it's not so easy to see when the CapsLock is on. I hope you find it useful as well. 
